### PR TITLE
Fix for newer Yubikey IDs

### DIFF
--- a/src/yubikey-invalidation.coffee
+++ b/src/yubikey-invalidation.coffee
@@ -19,9 +19,9 @@ https  = require 'https'
 
 module.exports = (robot) ->
   charset        = "cbdefghijklnrtuv"
-  otpRegex       = new RegExp("(cccccc[#{charset}]{38})$")
+  otpRegex       = new RegExp("(ccccc[#{charset}]{39})$")
   dvorakCharset  = "jxe.uidchtnbpygk"
-  dvorakOtpRegex = new RegExp("(jjjjjj[#{dvorakCharset}]{38})$")
+  dvorakOtpRegex = new RegExp("(jjjjj[#{dvorakCharset}]{39})$")
 
   messagePrefix = "Was that your YubiKey?"
 


### PR DESCRIPTION
Prior to this PR, a newer Yubikey may have an ID that starts with only five `c`s instead of six because they (likely) used up the namespace with later models. This PR relaxes the regular expression a bit to support the ID format.
